### PR TITLE
Add support for new vehicle color system and mark old ushort id methods as obsolete

### DIFF
--- a/UnturnedImages/API/Items/IItemImageDirectoryAsync.cs
+++ b/UnturnedImages/API/Items/IItemImageDirectoryAsync.cs
@@ -1,4 +1,5 @@
 ﻿using OpenMod.API.Ioc;
+using System;
 using System.Threading.Tasks;
 
 namespace UnturnedImages.API.Items
@@ -12,12 +13,24 @@ namespace UnturnedImages.API.Items
         /// <summary>
         /// Gets the URL for the specified item's image.
         /// </summary>
+        /// <param name="guid">The ID of the item asset.</param>
+        /// <param name="includeWorkshop">Whether or not workshop assets should be included.</param>
+        /// <returns>
+        /// The URL for the specified item's image if one exists, <c>null</c> otherwise.
+        /// Result may not be null even if image URL leads to 404 for performance reasons.
+        /// </returns>
+        Task<string?> GetItemImageUrlAsync(Guid guid, bool includeWorkshop = true);
+
+        /// <summary>
+        /// Gets the URL for the specified item's image.
+        /// </summary>
         /// <param name="id">The ID of the item asset.</param>
         /// <param name="includeWorkshop">Whether or not workshop assets should be included.</param>
         /// <returns>
         /// The URL for the specified item's image if one exists, <c>null</c> otherwise.
         /// Result may not be null even if image URL leads to 404 for performance reasons.
         /// </returns>
+        [Obsolete]
         Task<string?> GetItemImageUrlAsync(ushort id, bool includeWorkshop = true);
     }
 }

--- a/UnturnedImages/API/Items/IItemImageDirectorySync.cs
+++ b/UnturnedImages/API/Items/IItemImageDirectorySync.cs
@@ -1,4 +1,5 @@
 ﻿using OpenMod.API.Ioc;
+using System;
 
 namespace UnturnedImages.API.Items
 {
@@ -11,12 +12,25 @@ namespace UnturnedImages.API.Items
         /// <summary>
         /// Gets the URL for the specified item's image.
         /// </summary>
+        /// <param name="guid">The ID of the item asset.</param>
+        /// <param name="includeWorkshop">Whether or not workshop assets should be included.</param>
+        /// <returns>
+        /// The URL for the specified item's image if one exists, <c>null</c> otherwise.
+        /// Result may not be null even if image URL leads to 404 for performance reasons.
+        /// </returns>
+        string? GetItemImageUrlSync(Guid guid, bool includeWorkshop = true);
+
+
+        /// <summary>
+        /// Gets the URL for the specified item's image.
+        /// </summary>
         /// <param name="id">The ID of the item asset.</param>
         /// <param name="includeWorkshop">Whether or not workshop assets should be included.</param>
         /// <returns>
         /// The URL for the specified item's image if one exists, <c>null</c> otherwise.
         /// Result may not be null even if image URL leads to 404 for performance reasons.
         /// </returns>
+        [Obsolete]
         string? GetItemImageUrlSync(ushort id, bool includeWorkshop = true);
     }
 }

--- a/UnturnedImages/API/Vehicles/IVehicleImageDirectoryAsync.cs
+++ b/UnturnedImages/API/Vehicles/IVehicleImageDirectoryAsync.cs
@@ -1,5 +1,7 @@
 ﻿using OpenMod.API.Ioc;
+using System;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace UnturnedImages.API.Vehicles
 {
@@ -12,12 +14,37 @@ namespace UnturnedImages.API.Vehicles
         /// <summary>
         /// Gets the URL for the specified vehicle's image.
         /// </summary>
+        /// <param name="guid">The guid of the vehicle asset.</param>
+        /// <param name="includeWorkshop">Whether or not workshop assets should be included.</param>
+        /// <returns>
+        /// The URL for the specified vehicle's image if one exists, <c>null</c> otherwise.
+        /// Result may not be null even if image URL leads to 404 for performance reasons.
+        /// </returns>
+        Task<string?> GetVehicleImageUrlAsync(Guid guid, bool includeWorkshop = true);
+
+
+        /// <summary>
+        /// Gets the URL for the specified vehicle's image.
+        /// </summary>
+        /// <param name="guid">The guid of the vehicle asset.</param>
+        /// <param name="paintColor">The paint color image you want to get</param>
+        /// <param name="includeWorkshop">Whether or not workshop assets should be included.</param>
+        /// <returns>
+        /// The URL for the specified vehicle's image if one exists, <c>null</c> otherwise.
+        /// Result may not be null even if image URL leads to 404 for performance reasons.
+        /// </returns>
+        Task<string?> GetVehicleImageUrlAsync(Guid guid, Color32 paintColor, bool includeWorkshop = true);
+
+        /// <summary>
+        /// Gets the URL for the specified vehicle's image.
+        /// </summary>
         /// <param name="id">The ID of the vehicle asset.</param>
         /// <param name="includeWorkshop">Whether or not workshop assets should be included.</param>
         /// <returns>
         /// The URL for the specified vehicle's image if one exists, <c>null</c> otherwise.
         /// Result may not be null even if image URL leads to 404 for performance reasons.
         /// </returns>
+        [Obsolete]
         Task<string?> GetVehicleImageUrlAsync(ushort id, bool includeWorkshop = true);
     }
 }

--- a/UnturnedImages/API/Vehicles/IVehicleImageDirectorySync.cs
+++ b/UnturnedImages/API/Vehicles/IVehicleImageDirectorySync.cs
@@ -1,4 +1,6 @@
 ﻿using OpenMod.API.Ioc;
+using System;
+using UnityEngine;
 
 namespace UnturnedImages.API.Vehicles
 {
@@ -11,12 +13,36 @@ namespace UnturnedImages.API.Vehicles
         /// <summary>
         /// Gets the URL for the specified vehicle's image.
         /// </summary>
+        /// <param name="guid">The guid of the vehicle asset.</param>
+        /// <param name="includeWorkshop">Whether or not workshop assets should be included.</param>
+        /// <returns>
+        /// The URL for the specified vehicle's image if one exists, <c>null</c> otherwise.
+        /// Result may not be null even if image URL leads to 404 for performance reasons.
+        /// </returns>
+        string? GetVehicleImageUrlSync(Guid guid, bool includeWorkshop = true);
+
+        /// <summary>
+        /// Gets the URL for the specified vehicle's image.
+        /// </summary>
+        /// <param name="guid">The guid of the vehicle asset.</param>
+        /// <param name="paintColor">The paint color image you want to get</param>
+        /// <param name="includeWorkshop">Whether or not workshop assets should be included.</param>
+        /// <returns>
+        /// The URL for the specified vehicle's image if one exists, <c>null</c> otherwise.
+        /// Result may not be null even if image URL leads to 404 for performance reasons.
+        /// </returns>
+        string? GetVehicleImageUrlSync(Guid guid, Color32 paintColor, bool includeWorkshop = true);
+
+        /// <summary>
+        /// Gets the URL for the specified vehicle's image.
+        /// </summary>
         /// <param name="id">The ID of the vehicle asset.</param>
         /// <param name="includeWorkshop">Whether or not workshop assets should be included.</param>
         /// <returns>
         /// The URL for the specified vehicle's image if one exists, <c>null</c> otherwise.
         /// Result may not be null even if image URL leads to 404 for performance reasons.
         /// </returns>
+        [Obsolete]
         string? GetVehicleImageUrlSync(ushort id, bool includeWorkshop = true);
     }
 }

--- a/UnturnedImages/Configuration/Overrides/OverrideConfig.cs
+++ b/UnturnedImages/Configuration/Overrides/OverrideConfig.cs
@@ -8,11 +8,22 @@
         /// <summary>
         /// The ID range to which this override applies to.
         /// </summary>
-        public string Id { get; set; } = "";
+        public string? Id { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The Guid to which this override applies to.
+        /// </summary>
+        public string? Guid { get; set; } = string.Empty;
+
+
+        /// <summary>
+        /// The workshopId to which this override applies to.
+        /// </summary>
+        public string? WorkshopId { get; set; } = string.Empty;
 
         /// <summary>
         /// The repository where the asset's image should be fetched.
         /// </summary>
-        public string Repository { get; set; } = "";
+        public string Repository { get; set; } = string.Empty;
     }
 }

--- a/UnturnedImages/Items/ItemImageDirectory.cs
+++ b/UnturnedImages/Items/ItemImageDirectory.cs
@@ -11,8 +11,10 @@ using SDG.Unturned;
 using SilK.Unturned.Extras.Configuration;
 using SilK.Unturned.Extras.Events;
 using SmartFormat;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using UnturnedImages.API.Items;
 using UnturnedImages.Configuration.Overrides;
@@ -63,14 +65,27 @@ namespace UnturnedImages.Items
 
             var itemOverridesConfig = config.Get<ItemOverridesConfig>();
 
-            foreach (var overrideConfig in itemOverridesConfig.ItemOverrides)
+            foreach (var overrideConfig in itemOverridesConfig?.ItemOverrides ?? Array.Empty<OverrideConfig>())
             {
-                var range = RangeHelper.ParseMulti(overrideConfig.Id);
+                RepositoryOverride? @override = null;
                 var repository = overrideConfig.Repository;
 
-                var @override = new RepositoryOverride(range, repository);
+                if (!string.IsNullOrWhiteSpace(overrideConfig.Id))
+                {
+                    var range = RangeHelper.ParseMulti(overrideConfig.Id);
+                    @override = new RepositoryOverride(range, repository);
+                }
+                else if (!string.IsNullOrWhiteSpace(overrideConfig.Guid) && Guid.TryParse(overrideConfig.Guid, out var guid))
+                {
+                    @override = new RepositoryOverride(guid, repository);
+                }
+                else if (!string.IsNullOrEmpty(overrideConfig.WorkshopId) && ulong.TryParse(overrideConfig.WorkshopId, out var workshopId))
+                {
+                    @override = new RepositoryOverride(workshopId.ToString(), repository);
+                }
 
-                overrides.Add(@override);
+                if (@override != null)
+                    overrides.Add(@override);
             }
 
             _defaultItemRepository = config.GetValue<string?>("DefaultRepositories:Items", null);
@@ -96,22 +111,12 @@ namespace UnturnedImages.Items
         /// <inheritdoc />
         public string? GetItemImageUrlSync(ushort id, bool includeWorkshop)
         {
-            if (!includeWorkshop)
-            {
-                // Verify item ID is not workshop
+            var asset = Assets.find(EAssetType.ITEM, id);
 
-                if (Assets.find(EAssetType.ITEM, id) is not ItemAsset itemAsset ||
-                    itemAsset.assetOrigin == EAssetOrigin.WORKSHOP)
-                {
-                    return null;
-                }
-            }
+            if (asset == null)
+                return null;
 
-            var @override = _overrideRepositories.FirstOrDefault(x => x.Range.IsWithin(id));
-
-            var repository = @override?.Repository ?? _defaultItemRepository;
-
-            return repository == null ? null : Smart.Format(repository, new { ItemId = id });
+            return GetItemImageUrlSync(asset, includeWorkshop);
         }
 
 
@@ -119,6 +124,42 @@ namespace UnturnedImages.Items
         public Task<string?> GetItemImageUrlAsync(ushort id, bool includeWorkshop)
         {
             return Task.FromResult(GetItemImageUrlSync(id, includeWorkshop));
+        }
+
+        /// <inheritdoc />
+        public Task<string?> GetItemImageUrlAsync(Guid guid, bool includeWorkshop = true)
+        {
+            return Task.FromResult(GetItemImageUrlSync(guid, includeWorkshop));
+        }
+
+        /// <inheritdoc />
+        public string? GetItemImageUrlSync(Guid guid, bool includeWorkshop = true)
+        {
+            var asset = Assets.find<ItemAsset>(guid);
+
+            if (asset == null)
+                return null;
+
+            return GetItemImageUrlSync(asset, includeWorkshop);
+        }
+
+        private static readonly FieldInfo AssetOrigin = typeof(Asset).GetField("origin", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        private string? GetItemImageUrlSync(Asset asset, bool includeWorkshop = true)
+        {
+            if (AssetOrigin.GetValue(asset) is not AssetOrigin origin)
+                return null;
+
+            if (!includeWorkshop && origin.workshopFileId != 0)
+            {
+                return null;
+            }
+
+            var @override = _overrideRepositories.FirstOrDefault(x => x.Contains(asset.GUID, asset.id, origin.workshopFileId));
+
+            var repository = @override?.Repository ?? _defaultItemRepository;
+
+            return repository == null ? null : Smart.Format(repository, new { ItemId = asset.GUID });
         }
     }
 }

--- a/UnturnedImages/Repositories/RepositoryOverride.cs
+++ b/UnturnedImages/Repositories/RepositoryOverride.cs
@@ -1,17 +1,37 @@
-﻿using UnturnedImages.Ranges;
+﻿using Steamworks;
+using System;
+using UnturnedImages.Ranges;
 
 namespace UnturnedImages.Repositories
 {
     internal class RepositoryOverride
     {
-        public MultiRange Range { get; }
-
+        public MultiRange? Range { get; }
+        public Guid? Guid { get; }
+        public string? WorkshopId { get; } 
         public string Repository { get; }
 
         public RepositoryOverride(MultiRange range, string repository)
         {
             Range = range;
             Repository = repository;
+        }
+
+        public RepositoryOverride(Guid guid, string repository)
+        {
+            Guid = guid;
+            Repository = repository;
+        }
+
+        public RepositoryOverride(string workshopId, string repository)
+        {
+            WorkshopId = workshopId;
+            Repository = repository;
+        }
+
+        public bool Contains(Guid guid, ushort id, ulong workshopId)
+        {
+            return (Guid == guid) || (Range?.IsWithin(id) ?? false) || (WorkshopId?.Equals(workshopId) ?? false);
         }
     }
 }

--- a/UnturnedImages/UnturnedImages.csproj
+++ b/UnturnedImages/UnturnedImages.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net461</TargetFramework>
+		<TargetFramework>netstandard2.1</TargetFramework>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -28,12 +28,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.2">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="OpenMod.Unturned" Version="3.2.0" />
-		<PackageReference Include="SilK.Unturned.Extras" Version="1.6.5" />
+		<PackageReference Include="OpenMod.Unturned" Version="3.8.10" />
+		<PackageReference Include="SilK.Unturned.Extras" Version="1.7.5" />
+    <PackageReference Include="RestoreMonarchy.UnturnedRedist" Version="3.24.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/UnturnedImages/Vehicles/VehicleImageDirectory.cs
+++ b/UnturnedImages/Vehicles/VehicleImageDirectory.cs
@@ -123,7 +123,7 @@ namespace UnturnedImages.Vehicles
 
             if(asset is VehicleRedirectorAsset redirectorAsset)
             {
-                paintColor = redirectorAsset.SpawnPaintColor ?? redirectorAsset.SpawnPaintColor ?? new Color32(0,0,0,0);
+                paintColor = redirectorAsset.SpawnPaintColor ?? redirectorAsset.LoadPaintColor ?? new Color32(0,0,0,0);
             }
             else if(asset is VehicleAsset vehicleAsset && vehicleAsset.SupportsPaintColor)
             {

--- a/UnturnedImages/config.yaml
+++ b/UnturnedImages/config.yaml
@@ -11,6 +11,8 @@ DefaultRepositories:
 # Priority is based on which line is first. For example, if all lines below were uncommented,
 # the image URL for the item with an ID of 46001 would be https://cdn.jsdelivr.net/gh/SilKsPlugins/UnturnedIcons@images/modded/other2/items/{ItemId}.png
 ItemOverrides:
+#- WorkshoId: "3030546506" # The workshop mod you want to override
+#  Repository: "https://cdn.jsdelivr.net/gh/SilKsPlugins/UnturnedIcons@images/modded/3030546506/items/{ItemId}.png"
 #- Id: 46000 # The ID of the override.
 #  Repository: "https://cdn.jsdelivr.net/gh/SilKsPlugins/UnturnedIcons@images/modded/other/items/{ItemId}.png" # The repository of the override.
 #- Id: "46001-47000" # A range of IDs can be specified as well. You can specify multiple IDs using ranges. and multiple ranges by separating them with commas (',') or semi-colons (';').
@@ -21,5 +23,7 @@ ItemOverrides:
 # Repository overrides for vehicle images. Simply specify an ID, or list of IDs and their repository.
 # See the comments in the above ItemOverrides config for more information on configuring this.
 VehicleOverrides:
-#- Id: 46000 # The ID of the override.
+#- Guid: b1db3548447c4cde9f92d274e22f57a2 # The Guid of the override.
 #  Repository: "https://cdn.jsdelivr.net/gh/SilKsPlugins/UnturnedIcons@images/modded/other/vehicle/{VehicleId}.png" # The repository of the override.
+#- WorkshoId: "3030546506" # The workshop mod you want to override
+#  Repository: "https://cdn.jsdelivr.net/gh/SilKsPlugins/UnturnedIcons@images/modded/3030546506/items/{ItemId}.png"

--- a/samples/UnturnedImages.Example/CItemImageUrl.cs
+++ b/samples/UnturnedImages.Example/CItemImageUrl.cs
@@ -27,9 +27,11 @@ namespace UnturnedImages.Example
 
         protected override async UniTask OnExecuteAsync()
         {
-            var itemId = await Context.Parameters.GetAsync<ushort>(0);
+            var itemId = await Context.Parameters.GetAsync<string>(0);
+            if (!Guid.TryParse(itemId, out var guid))
+                throw new CommandWrongUsageException(Context);
 
-            var itemUrl = await _itemImageDirectory.GetItemImageUrlAsync(itemId);
+            var itemUrl = await _itemImageDirectory.GetItemImageUrlAsync(guid);
 
             if (itemUrl == null)
             {

--- a/samples/UnturnedImages.Example/CVehicleImageUrl.cs
+++ b/samples/UnturnedImages.Example/CVehicleImageUrl.cs
@@ -27,9 +27,11 @@ namespace UnturnedImages.Example
 
         protected override async UniTask OnExecuteAsync()
         {
-            var vehicleId = await Context.Parameters.GetAsync<ushort>(0);
+            var vehicleId = await Context.Parameters.GetAsync<string>(0);
+            if (!Guid.TryParse(vehicleId, out var guid))
+                throw new CommandWrongUsageException(Context);
 
-            var vehicleUrl = await _vehicleImageDirectory.GetVehicleImageUrlAsync(vehicleId);
+            var vehicleUrl = await _vehicleImageDirectory.GetVehicleImageUrlAsync(guid, true);
 
             if (vehicleUrl == null)
             {

--- a/samples/UnturnedImages.Example/UnturnedImages.Example.csproj
+++ b/samples/UnturnedImages.Example/UnturnedImages.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net461</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -16,11 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.2">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="OpenMod.Unturned" Version="3.2.0" />
+		<PackageReference Include="OpenMod.Unturned" Version="3.8.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tools/UnturnedImages.Module.Bootstrapper/UnturnedImages.Module.Bootstrapper.csproj
+++ b/tools/UnturnedImages.Module.Bootstrapper/UnturnedImages.Module.Bootstrapper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net461</TargetFramework>
+		<TargetFramework>net48</TargetFramework>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -12,8 +12,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="OpenMod.Unturned.Redist" Version="3.21.21" />
 		<PackageReference Include="dnlib" Version="3.3.4" />
+    <PackageReference Include="RestoreMonarchy.UnturnedRedist" Version="3.24.4" />
 	</ItemGroup>
 
 </Project>

--- a/tools/UnturnedImages.Module/Images/CustomImageTool.cs
+++ b/tools/UnturnedImages.Module/Images/CustomImageTool.cs
@@ -39,7 +39,7 @@ namespace UnturnedImages.Module.Images
             _lightComponent.enabled = false;
         }
 
-        public static Texture2D CaptureIcon(ushort id, ushort skin, Transform model, Transform icon, int width, int height, float orthoSize, bool readableOnCPU)
+        public static Texture2D CaptureIcon(Guid id, ushort skin, Transform model, Transform icon, int width, int height, float orthoSize, bool readableOnCPU)
         {
             if (_tool == null)
             {

--- a/tools/UnturnedImages.Module/Images/CustomVehicleTool.cs
+++ b/tools/UnturnedImages.Module/Images/CustomVehicleTool.cs
@@ -162,7 +162,7 @@ namespace UnturnedImages.Module.Images
 
             _camera.position = cameraPosition;
 
-            if(!vehicleAsset.IsPaintable)
+            if(!vehicleAsset.SupportsPaintColor)
             {
                 Texture2D texture = CustomImageTool.CaptureIcon(vehicleAsset.GUID, 0, vehicle, _camera,
                 vehicleIconInfo.Width, vehicleIconInfo.Height, orthographicSize, true);

--- a/tools/UnturnedImages.Module/UI/UIManager.cs
+++ b/tools/UnturnedImages.Module/UI/UIManager.cs
@@ -244,7 +244,7 @@ namespace UnturnedImages.Module.UI
             }
         }
 
-        private void OnExportModClicked(ISleekElement button, uint modId)
+        private void OnExportModClicked(ISleekElement button, ulong modId)
         {
             var vehicleAngles = new Vector3(
                 _vehicleAnglesXInput?.Value ?? 0,

--- a/tools/UnturnedImages.Module/UnturnedImages.Module.csproj
+++ b/tools/UnturnedImages.Module/UnturnedImages.Module.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net461</TargetFramework>
+		<TargetFramework>net48</TargetFramework>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -13,12 +13,8 @@
 
 	<ItemGroup>
 	  <PackageReference Include="Lib.Harmony" Version="2.1.1" />
-	  <PackageReference Include="OpenMod.UnityEngine.Redist" Version="2019.4.10">
-	    <IncludeAssets>compile</IncludeAssets>
-	  </PackageReference>
-	  <PackageReference Include="OpenMod.Unturned.Redist" Version="3.22.15">
-	    <IncludeAssets>compile</IncludeAssets>
-	  </PackageReference>
+	  <PackageReference Include="OpenMod.UnityEngine.Redist" Version="2021.3.29.1" />
+	  <PackageReference Include="RestoreMonarchy.UnturnedRedist" Version="3.24.4" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
A new paint color system was introduced for vehicles. This pr adds support for getting all the vehicles and it's colors.
ushort ids were removed for vanilla vehicles so their methods were marked as obsolete and replaced with new ones that works with guid instead.
new option paint color was added to the get vehicle image url method to support a specified color.
MultiRange feature should still work for the vehicles and items that still have their ushort ids. A replacement for this was added. WorkshopId and Guid. To override an entire mod you can use the workshop id and to override specific items/vehicles you can use the Guid. New image exports will use the workshop id instead